### PR TITLE
Fix charts rendering: use Chart.js UMD, simplify charts init

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,8 +242,8 @@
         </div>
     </div>
 
-    <!-- Chart.js CDN - Versão Estável -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <!-- Chart.js CDN - Versão UMD (garante window.Chart) -->
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>
     
     <!-- Verificação de Chart.js -->
     <script>
@@ -252,7 +252,7 @@
             if (typeof Chart === 'undefined') {
                 console.error('❌ Chart.js falhou ao carregar. Tentando alternativa...');
                 const script = document.createElement('script');
-                script.src = 'https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.0/chart.min.js';
+                script.src = 'https://unpkg.com/chart.js@4.4.0/dist/chart.umd.js';
                 script.onload = () => console.log('✅ Chart.js carregado via fallback');
                 script.onerror = () => console.error('❌ Fallback também falhou');
                 document.head.appendChild(script);
@@ -264,7 +264,7 @@
 
     <!-- Scripts da aplicação -->
     <script src="js/app.js"></script>
-    <script src="js/charts.js"></script>
+    <script src="js/charts-simple.js"></script>
 
 </body>
 

--- a/js/app.js
+++ b/js/app.js
@@ -1035,19 +1035,16 @@ document.addEventListener('DOMContentLoaded', () => {
                     task.completedAt = new Date().toISOString();
                 }
 
+                window.dashboard.tasks.push(task);
+            });
 
-                    window.dashboard.tasks.push(task);
-                });
+            window.dashboard.saveToStorage();
+            window.dashboard.renderTasks();
+            window.dashboard.updateMetrics();
+            window.dashboard.showFeedback('Dados de teste adicionados!', 'success');
+        };
 
-                window.dashboard.saveToStorage();
-                window.dashboard.renderTasks();
-                window.dashboard.updateMetrics();
-                window.dashboard.showFeedback('Dados de teste adicionados!', 'success');
-            };
-
-
-            console.log('💻 Modo desenvolvimento ativo. Use addTestData() para adicionar dados de teste.');
-        }
+        console.log('💻 Modo desenvolvimento ativo. Use addTestData() para adicionar dados de teste.');
     }
 
 

--- a/js/charts-simple.js
+++ b/js/charts-simple.js
@@ -254,6 +254,9 @@ class ProductivityCharts {
     }
 }
 
+// Disponibilizar no escopo global para diagnósticos e uso externo
+window.ProductivityCharts = window.ProductivityCharts || ProductivityCharts;
+
 // Função única de inicialização
 function initializeCharts() {
     // Verificar se já foi inicializado

--- a/test-dashboard.html
+++ b/test-dashboard.html
@@ -99,10 +99,20 @@
             appScript.src = 'js/app.js';
             appScript.onload = function() {
                 console.log('✅ app.js carregado');
-                
-                // Carregar charts.js
+
+                // Inicializar o Dashboard manualmente, pois DOMContentLoaded já ocorreu
+                try {
+                    if (!window.dashboard && typeof ProductivityDashboard === 'function') {
+                        window.dashboard = new ProductivityDashboard();
+                        console.log('✅ Dashboard inicializado no ambiente de teste');
+                    }
+                } catch (e) {
+                    console.error('❌ Erro ao inicializar o Dashboard no teste:', e);
+                }
+
+                // Carregar charts (versão simples/estável)
                 const chartsScript = document.createElement('script');
-                chartsScript.src = 'js/charts.js';
+                chartsScript.src = 'js/charts-simple.js';
                 chartsScript.onload = function() {
                     console.log('✅ charts.js carregado');
                     setTimeout(() => {


### PR DESCRIPTION
Resumo das correções:
- Troca para Chart.js UMD (4.4.0) com fallback para garantir `window.Chart`
- Substituição de `js/charts.js` instável por `js/charts-simple.js`
- Correção de erro de sintaxe em `js/app.js` (addTestData)
- Exposição de `ProductivityCharts` em `window` e ajuste no `test-dashboard.html` para inicializar dashboard quando injetado

Impacto:
- Gráficos voltam a renderizar de forma confiável
- Teste diagnóstico (`test-dashboard.html`) passa a validar dependências corretamente

Branches:
- base: `main`
- head: `fix`
